### PR TITLE
Change BAD to BHD in NBE results

### DIFF
--- a/lib/egp_rates/nbe.rb
+++ b/lib/egp_rates/nbe.rb
@@ -60,7 +60,9 @@ module EGPRates
       raw_data.each_with_object(sell: {}, buy: {}) do |row, result|
         sell_rate = row[4].strip.to_f
         buy_rate  = row[3].strip.to_f
-        currency  = row[2].strip.to_sym
+        # Bahraini Dinar is BHD not BAD
+        # Changing it for consistency
+        row[2].strip == 'BAD' ? currency = :BHD : currency = row[2].strip.to_sym
 
         result[:sell][currency] = sell_rate
         result[:buy][currency]  = buy_rate

--- a/lib/egp_rates/nbe.rb
+++ b/lib/egp_rates/nbe.rb
@@ -60,9 +60,15 @@ module EGPRates
       raw_data.each_with_object(sell: {}, buy: {}) do |row, result|
         sell_rate = row[4].strip.to_f
         buy_rate  = row[3].strip.to_f
+        currency = row[2].strip.to_sym
         # Bahraini Dinar is BHD not BAD
-        # Changing it for consistency
-        row[2].strip == 'BAD' ? currency = :BHD : currency = row[2].strip.to_sym
+        # Also Qatar Rial is QAR not QTR
+        # Changing them for consistency
+        if currency == :BAD
+          currency = :BHD
+        elsif currency == :QTR
+          currency = :QAR
+        end
 
         result[:sell][currency] = sell_rate
         result[:buy][currency]  = buy_rate

--- a/spec/egp_rates/nbe_spec.rb
+++ b/spec/egp_rates/nbe_spec.rb
@@ -61,7 +61,7 @@ describe EGPRates::NBE do
         KWD: 58.2254,
         NOK: 2.1132,
         OMR: 46.1506,
-        QTR: 4.8748,
+        QAR: 4.8748,
         SAR: 4.7327,
         SEK: 1.9331,
         USD: 17.75
@@ -83,7 +83,7 @@ describe EGPRates::NBE do
         KWD: 57.377,
         NOK: 2.0682,
         OMR: 45.4133,
-        QTR: 4.8053,
+        QAR: 4.8053,
         SAR: 4.6654,
         SEK: 1.8968,
         USD: 17.5

--- a/spec/egp_rates/nbe_spec.rb
+++ b/spec/egp_rates/nbe_spec.rb
@@ -50,7 +50,7 @@ describe EGPRates::NBE do
       expect(bank.send(:parse, raw_data)[:sell]).to match(
         AED: 4.8327,
         AUD: 13.2557,
-        BAD: 47.086,
+        BHD: 47.086,
         CAD: 13.3902,
         CHF: 17.6144,
         DKK: 2.5503,
@@ -72,7 +72,7 @@ describe EGPRates::NBE do
       expect(bank.send(:parse, raw_data)[:buy]).to match(
         AED: 4.7645,
         AUD: 12.9535,
-        BAD: 46.4166,
+        BHD: 46.4166,
         CAD: 13.1381,
         CHF: 17.2891,
         DKK: 2.4995,


### PR DESCRIPTION
The NBE shows a wrong iso code for the Bahraini Dinar which will make the gem results isn't consistent so I made a quick fix for it. 